### PR TITLE
return the reason if there is no value

### DIFF
--- a/src/helpers/fetchData/fetchData.js
+++ b/src/helpers/fetchData/fetchData.js
@@ -46,10 +46,11 @@ const executeFetchData = (component, match, req, res, debug) => {
       Q.allSettled(keys.map(key => fetch[key]))
         .then(responses => {
           responses.forEach((data, index) => {
-            props[keys[index]] = data.value
-
-            if (!data.value) {
-              debug && console.warn(`Fetch #${index + 1} in ${component.displayName} returned undefined.`)
+            if (data.value) {
+              props[keys[index]] = data.value
+            } else {
+              props[keys[index]] = data.reason
+              debug && console.warn(`Fetch #${index + 1} in ${component.displayName} returned: ${data.reason}`)
             }
           })
 


### PR DESCRIPTION
This should be safe to do.  Or you could explicitly look for 'fullfilled' ?

From Q's allSettled docs:

```
Q.allSettled(promises)
.then(function (results) {
    results.forEach(function (result) {
        if (result.state === "fulfilled") {
            var value = result.value;
        } else {
            var reason = result.reason;
        }
    });
});
```