### PR TITLE
if fetchData has an _exclude child dont add it to the dataFromServerR…

### DIFF
--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -101,7 +101,7 @@ const serverRender = async ({
       fetchedProps.forEach(prop => {
         const obj = prop.value
         const name = Object.keys(obj)[0]
-        if (!obj[name]._exclude) {
+        if (!obj[name]._excludeFromHydration) {
           _extends(filteredProps, obj)
         }
       })

--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -95,13 +95,18 @@ const serverRender = async ({
   Q.allSettled(dataCalls)
     .then(async fetchedProps => {
       debug('Fetched props... ', fetchedProps)
-      fetchedProps = fetchedProps.map(prop => prop.value)
 
-      if (fetchedProps.length) {
-        fetchedProps = fetchedProps.reduce((prop, props) => ({ ...props, ...prop }))
-      }
+      const filteredProps = {}
 
-      state._dataFromServerRender = fetchedProps
+      fetchedProps.forEach(prop => {
+        const obj = prop.value
+        const name = Object.keys(obj)[0]
+        if (!obj[name]._exclude) {
+          _extends(filteredProps, obj)
+        }
+      })
+
+      state._dataFromServerRender = filteredProps
 
       const app = ReactDOMServer.renderToString((
         <SSRProvider value={fetchedProps}>

--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -102,7 +102,7 @@ const serverRender = async ({
         const obj = prop.value
         const name = Object.keys(obj)[0]
         if (!obj[name]._excludeFromHydration) {
-          _extends(filteredProps, obj)
+          filteredProps[name] = obj[name]
         }
       })
 

--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -98,11 +98,12 @@ const serverRender = async ({
 
       const filteredProps = {}
 
-      fetchedProps.forEach(prop => {
-        const obj = prop.value
-        const name = Object.keys(obj)[0]
-        if (!obj[name]._excludeFromHydration) {
-          filteredProps[name] = obj[name]
+      fetchedProps.forEach(props => {
+        const fetchedObject = props.value
+        const keyOfFetchedObject = Object.keys(fetchedObject)[0]
+        const objectOfFetchedValues = fetchedObject[keyOfFetchedObject]
+        if (!objectOfFetchedValues._excludeFromHydration) {
+          filteredProps[keyOfFetchedObject] = objectOfFetchedValues
         }
       })
 


### PR DESCRIPTION
I think it would be useful to allow optionally excluding the json returned on the server from fetchData 

I've set this up to look for an _exclude boolean child.  If it exists, it will not add it to _dataFromServerRender

If it doesn't exist, it will work as before.