### PR TITLE
Feature/separate read write flags

### DIFF
--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -60,7 +60,7 @@ const serverRender = async ({
   }
 
   // does req.url include query parameters? do we want to cache routes with query parameters?
-  if (safeToCache && hasRedis && cache && cache.mode === 'full') {
+  if (hasRedis && cache && cache.mode === 'full') {
     const key = `${cache.keyPrefix}${req.url}`
 
     if (await redisClient.exists(key)) {


### PR DESCRIPTION
I think it would be useful to be able to separately decide if we want to read from the cache, and write to the cache.

A page might be in a state where although we don't want to store it after generating it, we do want to check the cache for the same page in a previous state

I have left the original useCacheForRequest which was used for both reading and writing in place for backwards compatibility