### PR TITLE
Feature/dont write to cache on error

### DIFF
--- a/src/serverRender.js
+++ b/src/serverRender.js
@@ -100,6 +100,7 @@ const serverRender = async ({
       debug('Fetched props... ', fetchedProps)
 
       const filteredProps = {}
+      let preventCaching = false
 
       fetchedProps.forEach(props => {
         const fetchedObject = props.value
@@ -108,6 +109,7 @@ const serverRender = async ({
         if (!objectOfFetchedValues._excludeFromHydration) {
           filteredProps[keyOfFetchedObject] = objectOfFetchedValues
         }
+        if (objectOfFetchedValues._preventCaching) preventCaching = true
       })
 
       state._dataFromServerRender = filteredProps
@@ -126,7 +128,7 @@ const serverRender = async ({
       const page = `<!DOCTYPE html>${wrapper}`
       const status = req.status || statusCode
 
-      if (writeCache && status >= 200 && status < 300) {
+      if (!preventCaching && writeCache && status >= 200 && status < 300) {
         const { duration = 1800, keyPrefix = '' } = cache
         const key = `${keyPrefix}${req.url}`
         await storePageInCache(redisClient, key, page, duration)


### PR DESCRIPTION
Thought of another one..

Each fetchData should have the ability to prevent the page from caching
i.e.
if an api fails - we don't want to cache the errored page for the next user